### PR TITLE
chore: entando-k8s-controller-coordinator to 6.0.45

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -1,4 +1,7 @@
 dependencies:
+- name: entando-k8s-controller-coordinator
+  repository: http://jenkins-x-chartmuseum:8080
+  version: 6.0.45
 - alias: expose
   name: exposecontroller
   repository: http://chartmuseum.jenkins-x.io


### PR DESCRIPTION
chore: Promote entando-k8s-controller-coordinator to version 6.0.45