### PR TITLE
chore: entando-k8s-controller-coordinator to 6.0.60

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -4,7 +4,7 @@ dependencies:
   version: 6.0.26
 - name: entando-k8s-controller-coordinator
   repository: http://jenkins-x-chartmuseum:8080
-  version: 6.0.59
+  version: 6.0.60
 - alias: expose
   name: exposecontroller
   repository: http://chartmuseum.jenkins-x.io


### PR DESCRIPTION
chore: Promote entando-k8s-controller-coordinator to version 6.0.60