### PR TITLE
chore: entando-k8s-controller-coordinator to 6.1.4

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -1,7 +1,7 @@
 dependencies:
 - name: entando-k8s-controller-coordinator
   repository: http://jenkins-x-chartmuseum:8080
-  version: 6.1.3
+  version: 6.1.4
 - name: entando-process-driven-plugin
   repository: http://jenkins-x-chartmuseum:8080
   version: 6.0.2


### PR DESCRIPTION
chore: Promote entando-k8s-controller-coordinator to version 6.1.4