### PR TITLE
chore: octo-easyclaim-server to 0.0.9

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -18,4 +18,4 @@ dependencies:
   version: 0.0.9
 - name: octo-easyclaim-server
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.8
+  version: 0.0.9


### PR DESCRIPTION
chore: Promote octo-easyclaim-server to version 0.0.9