### PR TITLE
chore: entando-plugin-jpcontentscheduler to 6.2.1

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -2,6 +2,9 @@ dependencies:
 - name: entando-k8s-controller-coordinator
   repository: http://jenkins-x-chartmuseum:8080
   version: 6.1.6
+- name: entando-plugin-jpcontentscheduler
+  repository: http://jenkins-x-chartmuseum:8080
+  version: 6.2.1
 - name: entando-process-driven-plugin
   repository: http://jenkins-x-chartmuseum:8080
   version: 6.0.2


### PR DESCRIPTION
chore: Promote entando-plugin-jpcontentscheduler to version 6.2.1