### PR TITLE
chore: entando-k8s-controller-coordinator to 6.1.8

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -1,7 +1,7 @@
 dependencies:
 - name: entando-k8s-controller-coordinator
   repository: http://jenkins-x-chartmuseum:8080
-  version: 6.1.7
+  version: 6.1.8
 - name: entando-plugin-jpcontentscheduler
   repository: http://jenkins-x-chartmuseum:8080
   version: 6.2.1


### PR DESCRIPTION
chore: Promote entando-k8s-controller-coordinator to version 6.1.8