### PR TITLE
chore: octo-easyclaim-mock to 0.0.18

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -18,7 +18,7 @@ dependencies:
   version: 2.3.114
 - name: octo-easyclaim-mock
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.17
+  version: 0.0.18
 - name: octo-easyclaim-server
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.33


### PR DESCRIPTION
chore: Promote octo-easyclaim-mock to version 0.0.18