### PR TITLE
chore: entando-k8s-controller-coordinator to 6.2.17

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -1,7 +1,7 @@
 dependencies:
 - name: entando-k8s-controller-coordinator
   repository: http://jenkins-x-chartmuseum:8080
-  version: 6.2.16
+  version: 6.2.17
 - alias: expose
   name: exposecontroller
   repository: http://chartmuseum.jenkins-x.io


### PR DESCRIPTION
chore: Promote entando-k8s-controller-coordinator to version 6.2.17